### PR TITLE
chore: docker compose 설정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# Development Dockerfile for NestJS Server
+FROM node:24.12.0-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install all dependencies (including dev dependencies)
+RUN npm install
+
+# Copy source code
+# Note: For hot-reload, mount source as volume in docker-compose
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+
+# Start development server with hot-reload
+CMD ["npm", "run", "start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  # Frontend Service (React)
+  frontend:
+    container_name: teamConfig-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - '5173:5173' # Host:Container
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules # 프론트엔드도 동일한 문제를 방지하기 위해 추가 권장
+    environment:
+      - WATCHPACK_POLLING=true
+      - CHOKIDAR_USEPOLLING=true
+    stdin_open: true
+    tty: true
+    networks:
+      - web-os-network
+
+  # Backend Service (Node.js)
+  backend:
+    container_name: teamConfig-backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./backend:/app
+      - /app/node_modules # <--- [핵심 수정] 이미지 내부의 node_modules를 보존합니다.
+    networks:
+      - web-os-network
+
+networks:
+  web-os-network:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# Development Dockerfile for NestJS Server
+FROM node:24.12.0-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install all dependencies (including dev dependencies)
+RUN npm install
+
+# Copy source code
+# Note: For hot-reload, mount source as volume in docker-compose
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    host: '0.0.0.0',
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8589,6 +8589,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
## ✅ 작업 내용

- docker compose 설정을 통한 개발 환경 설정

## 🧪 테스트 방법 (옵션)

1. 프로젝트 루트 디렉토리에서 docker compose up --build 실행하여 컨테이너 실행 확인

## 💬 참고 사항
[docker compose 실행 가이드](https://github.com/boostcampwm2025/web15-ipconfig/wiki/Docker-Compose-%EC%8B%A4%ED%96%89-%EA%B0%80%EC%9D%B4%EB%93%9C)

## 시작하기

프론트엔드 및 백엔드 서비스를 빌드하고 시작하려면 프로젝트의 루트 디렉터리(`docker-compose.yml` 파일이 있는 곳)로 이동하여 다음 명령을 실행하십시오.

```bash
docker-compose up --build
```

`--build` 플래그는 `Dockerfile` 또는 빌드 컨텍스트에 변경 사항이 있는 경우 Docker 이미지가 다시 빌드되도록 합니다.

## 서비스 접속

서비스가 실행 중이면 다음 주소로 접속할 수 있습니다.

### 프론트엔드

프론트엔드 애플리케이션은 웹 브라우저에서 다음 주소로 접근할 수 있습니다.
[http://localhost:5173](http://localhost:5173)

### 백엔드

백엔드 API는 다음 주소로 접근할 수 있습니다.
[http://localhost:3000](http://localhost:3000)

## 서비스 중지

실행 중인 서비스를 중지하고 컨테이너를 제거하려면 `docker-compose up`이 실행 중인 터미널에서 `Ctrl+C`를 누르십시오.

또는 프로젝트의 루트 디렉터리에서 별도의 터미널에서 다음 명령을 실행할 수 있습니다.

```bash
docker-compose down
```

이 명령은 `up` 명령으로 생성된 컨테이너, 네트워크 및 볼륨을 중지하고 제거합니다.

