### PR TITLE
fix: 배포 시 예전 이미지 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy with Docker Compose
 on:
   push:
     branches:
-      - fix/delete-legacy-image
+      - main
 
 env:
   NODE_VERSION: '24.12.0'


### PR DESCRIPTION
## ✅ 작업 내용
- 배포 시 옛날 이미지 제거

## 📸 스크린샷 / 데모 (옵션)

<img width="887" height="183" alt="image" src="https://github.com/user-attachments/assets/cd4e661c-2d62-4b57-bbaa-a0c92c22e0f0" />

## 💬 참고 사항

- [ADR: 03. 도커와 서버 용량](https://www.notion.so/03-2e274a2c070c8082b6e9e43ddfca8dd6?source=copy_link)