### PR TITLE
feat: 캔버스 확대, 축소 방식 변경

### DIFF
--- a/frontend/src/features/canvas/CanvasContent.tsx
+++ b/frontend/src/features/canvas/CanvasContent.tsx
@@ -10,7 +10,6 @@ interface CanvasContainerProps {
   handlePointerDown: (e: React.PointerEvent) => void;
   handlePointerMove: (e: React.PointerEvent) => void;
   handlePointerUp: () => void;
-  handleWheel: (e: React.WheelEvent) => void;
   isPanning: boolean;
   remoteCursor: Record<string, Cursor>;
 }
@@ -21,7 +20,6 @@ function CanvasContent({
   handlePointerDown,
   handlePointerMove,
   handlePointerUp,
-  handleWheel,
   isPanning,
   remoteCursor,
 }: CanvasContainerProps) {
@@ -38,7 +36,6 @@ function CanvasContent({
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
-      onWheel={handleWheel}
     >
       {/* 배경 패턴 */}
       <div

--- a/frontend/src/features/canvas/hooks/useCanvas.ts
+++ b/frontend/src/features/canvas/hooks/useCanvas.ts
@@ -1,5 +1,5 @@
 import type { Camera } from '@/common/types/camera';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ZOOM_CONFIG } from '../constants/zoom';
 
 export default function useCanvas() {
@@ -36,19 +36,22 @@ export default function useCanvas() {
     zoomTo(delta, centerX, centerY);
   };
 
-  const handleWheel = (e: React.WheelEvent) => {
-    e.preventDefault();
+  const handleWheel = (e: WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      e.stopPropagation();
 
-    const container = containerRef.current;
-    if (!container) return;
+      const container = containerRef.current;
+      if (!container) return;
 
-    const rect = container.getBoundingClientRect();
-    const mouseX = e.clientX - rect.left;
-    const mouseY = e.clientY - rect.top;
+      const rect = container.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
 
-    const zoomDelta = -e.deltaY * ZOOM_CONFIG.WHEEL_SENSITIVITY;
+      const zoomDelta = -e.deltaY * ZOOM_CONFIG.WHEEL_SENSITIVITY;
 
-    zoomTo(zoomDelta, mouseX, mouseY);
+      zoomTo(zoomDelta, mouseX, mouseY);
+    }
   };
 
   const handlePointerDown = (e: React.PointerEvent) => {
@@ -88,10 +91,20 @@ export default function useCanvas() {
     return { x: worldX, y: worldY };
   };
 
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleWheel]);
+
   return {
     camera,
     handleZoomButton,
-    handleWheel,
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,

--- a/frontend/src/pages/workspace/WorkSpacePage.tsx
+++ b/frontend/src/pages/workspace/WorkSpacePage.tsx
@@ -42,7 +42,6 @@ function WorkSpacePage() {
     handleZoomButton,
     isPanning,
     getMousePosition,
-    handleWheel,
   } = useCanvas();
 
   // 임시로 고정된 워크스페이스 / 사용자 정보 (실제 서비스에서는 라우팅/로그인 정보 사용)
@@ -134,7 +133,6 @@ function WorkSpacePage() {
             handlePointerDown={handlePointerDown}
             handlePointerMove={handleCanvasPointerMove}
             handlePointerUp={handlePointerUp}
-            handleWheel={handleWheel}
             isPanning={isPanning}
             remoteCursor={remoteCursors}
           />


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #77

## ✅ 작업 내용
- 기존 마우스 휠만 이용한 캔버스 확대, 축소 방식에서 마우스 휠+컨트롤(커맨드)키 함께 사용하는 방식으로 변경
- 맥의 경우 트랙패드 핀치 줌 시 전체 화면이(캔버스만이 아니라) 확대되는 문제 해결

## 💬 참고 사항
1. 마우스 휠을 이용한 줌에 윈도우의 경우에는 컨트롤키, 맥의 경우에는 커맨드 키와 같이 제한을 걸려고 했습니다
하지만 이렇게 하는 경우 조건문이 복잡해지고, 맥의 경우 브라우저가 트랙핀치 제스처를 ctrlKey + 마우스 휠 이벤트로 변조해서 보내주기 때문에 command 키로만 강제하면 유저가 트랙핀치 줌을 쓸 수 없다는 문제를 발견했습니다(https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent)
=> 따라서 유연하게 마우스 휠 이벤트 발생시 컨트롤키나 커맨드 키 모두 허용하여, 둘 중 하나의 키라도 눌려있으면 확대, 축소가 가능하도록 수정하였습니다
<img width="788" height="76" alt="image" src="https://github.com/user-attachments/assets/d1260f8a-4079-4f37-b533-c06d9502877c" />

2. 브라우저에서 트랙핀치 줌을 테스트 하면서, 트랙핀치 줌을 하면 캔버스가 확대, 축소 되는 것이 아니라 화면 전체가 같이 확대되는 문제를 발견했습니다.
**문제 원인**: 브라우저의 기본 동작을 React의 이벤트 시스템이 완벽하게 막지 못해서 발생
최신 브라우저들은 스크롤 성능 향상을 위해 wheel 이벤트를 passive 모드로 처리합니다. 브라우저가 자바스크립트가 스크롤을 막을지 안 막을지 기다리지 않고 일단 스크롤/줌을 해버리는 방식입니다. 이 때문에 e.preventDefault()가 무시되는 경우가 많습니다.

> passive 모드란?
이 이벤트 리스너 안에서 스크롤을 멈추는(preventDefault()) 코드는 실행하지 않을 테니, 묻지 말고 즉시 스크롤 하는 모드
브라우저는 기본적으로 자바스크립트의 실행이 완료될 때까지 화면 그리기(스크롤)을 대기한다. wheel 이벤트 발생하면 브라우저는 개발자가 자바스크립트로 스크롤을 막았는지(=preventDefault)를 확인하기 위해 자바스크립트 실행을 기다린다. 자바스크립트 실행이 끝나고 나서야 스크롤이 막히지 않았음을 확인하고 화면을 내리는데 자바스크립트 연산이 조금이라도 무거우면, 사용자는 스크롤할 때 화면이 뚝뚝 끊긴다고 느끼게 된다.
이 현상을 막기 위해서 이벤트를 passive 모드로 처리하면 휠 이벤트가 발생했을 때 브라우저는 자바스크립트 실행을 기다리지 않고 즉시 화면을 스크롤해서 성능을 향상시킨다.

**해결 방법**: React의 onWheel 속성 대신, useEffect로 passive: false 옵션을 줘서 이벤트를 직접 등록하여 해결했습니다
