### PR TITLE
hotfix: git 컨벤션 위젯 FE 데이터 구조와 BE DTO 불일치 해결

### DIFF
--- a/backend/src/markdown/markdown.service.ts
+++ b/backend/src/markdown/markdown.service.ts
@@ -32,7 +32,7 @@ export class MarkdownService {
       let strategyName = '';
       let description = '';
 
-      switch (content.data.strategy) {
+      switch (content.strategy) {
         case 'GITHUB_FLOW':
           strategyName = 'GitHub Flow';
           description = 'main 브랜치를 중심으로 feature 브랜치에서 작업';
@@ -68,11 +68,11 @@ export class MarkdownService {
     lines.push('| :--- | :--- | :--- |');
 
     gitConventionWidgets.forEach((content) => {
-      const mainBranch = content.data.branchRules.mainBranch || '-';
-      const developBranch = content.data.branchRules.developBranch || '-';
+      const mainBranch = content.branchRules.mainBranch || '-';
+      const developBranch = content.branchRules.developBranch || '-';
       const prefixes =
-        content.data.branchRules.prefixes.length > 0
-          ? content.data.branchRules.prefixes.join(', ')
+        content.branchRules.prefixes.length > 0
+          ? content.branchRules.prefixes.join(', ')
           : '-';
 
       lines.push(`| ${mainBranch} | ${developBranch} | ${prefixes} |`);
@@ -96,8 +96,8 @@ export class MarkdownService {
 
     gitConventionWidgets.forEach((content) => {
       const commitTypes =
-        content.data.commitConvention.commitTypes.length > 0
-          ? content.data.commitConvention.commitTypes.join(', ')
+        content.commitConvention.commitTypes.length > 0
+          ? content.commitConvention.commitTypes.join(', ')
           : '-';
 
       lines.push(`| ${commitTypes} |`);

--- a/backend/src/widget/dto/widget-content.dto.ts
+++ b/backend/src/widget/dto/widget-content.dto.ts
@@ -118,20 +118,25 @@ export class GitConventionContentDto implements BaseContentDto {
   @IsEnum(WidgetType)
   readonly widgetType = WidgetType.GIT_CONVENTION;
 
+  @ApiProperty({ example: 'GITHUB_FLOW' })
+  @IsString()
+  readonly strategy: GitStrategy;
+
   @ApiProperty({
     example: {
-      strategy: 'GITHUB_FLOW',
-      branchRules: {
-        mainBranch: 'main',
-        developBranch: 'develop',
-        prefixes: [],
-      },
-      commitConvention: { useGitmoji: false, commitTypes: [] },
+      mainBranch: 'main',
+      developBranch: 'develop',
+      prefixes: [],
     },
   })
   @IsObject()
-  @ValidateNested()
-  readonly data: GitConventionData;
+  readonly branchRules: BranchRuleState;
+
+  @ApiProperty({
+    example: { useGitmoji: false, commitTypes: [] },
+  })
+  @IsObject()
+  readonly commitConvention: CommitConventionState;
 }
 
 // Update용 Partial DTO Export


### PR DESCRIPTION
## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- 프론트엔드 데이터 구조와 일치하도록 GitConventionContentDto의 중첩된 `data` 래퍼 제거
- `content` 객체에서 직접 속성에 접근하도록 MarkdownService 로직 수정

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="768" height="818" alt="image" src="https://github.com/user-attachments/assets/36cacc70-1de5-4db8-9cb1-aec11d0ceaf4" />