### PR TITLE
fix: 커서 위치 정렬 문제 수정

### DIFF
--- a/frontend/src/common/components/cursor/CursorLayer.tsx
+++ b/frontend/src/common/components/cursor/CursorLayer.tsx
@@ -13,11 +13,10 @@ function CursorLayer() {
       {cursorList.map((cursor) => (
         <div
           key={cursor.userId}
-          className="pointer-events-none fixed z-[100]"
+          className="pointer-events-none absolute z-[100]"
           style={{
             left: `${cursor.x}px`,
             top: `${cursor.y}px`,
-            transform: 'translate(-50%, -50%)',
             transition: 'all 0.4s cubic-bezier(0.25, 1, 0.5, 1)',
           }}
         >


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- PR 관련 라벨을 붙여주세요! -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- #243 

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- 커서 아이콘 정렬 수정
  - 커서 아이콘을 중앙 정렬하던 부분을 제거하여 커서 아이콘의 top-left가 전달받은 좌표를 가리키도록 수정
- absolute로 동작하던 fixed를 absolute로 변경
  - 부모(CanvasWrapper)에 transform 속성이 있어 absolute로 동작하고 있었음

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="1746" height="876" alt="image" src="https://github.com/user-attachments/assets/70d19036-61ab-49bd-afe6-7961e884765b" />


## 💬 참고 사항

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
