### PR TITLE
chore: SSL 적용을 위한 Nginx, docker compose 설정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - app-network
     environment:
       - NODE_ENV=production
-      - HOST_URL=http://49.50.138.164/
+      - HOST_URL=${HOST_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
@@ -22,6 +22,10 @@ services:
     container_name: web15-ipconfig-frontend
     ports:
       - '80:80'
+      - '443:443'
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
     networks:
       - app-network
     environment:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,25 @@
 server {
   listen 80;
-  server_name _;
+  server_name teamconfig.work;
+
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+  }
+
+  location / {
+      return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+  server_name teamconfig.work;
+
+  ssl_certificate /etc/letsencrypt/live/teamconfig.work/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/teamconfig.work/privkey.pem;
+
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers HIGH:!aNULL:!MD5;
 
   root /usr/share/nginx/html;
   index index.html;


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- PR 관련 라벨을 붙여주세요! -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- #266 
- #212 

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->
실시간 동기화 협업 툴인 우리 서비스의 특성상 네트워크 지연(Latency) 최소화가 필수적입니다. 기존 Cloudflare의 Proxied 모드는 보안 및 간편한 SSL 기능을 제공하지만, 라우팅 과정에서 평균 144ms 이상의 지연을 유발하는 문제가 확인되었습니다.

이를 해결하기 위해 Cloudflare를 단순 DNS 용도로만 사용(DNS Only)하기로 결정하였고, 이에 따라 Cloudflare가 제공하던 SSL 기능이 비활성화되므로, NCP 인스턴스 내부에서 Certbot을 사용하여 직접 SSL 인증서를 발급받고 관리하는 구조로 변경했습니다.

- SSL 인증서 도입: Host 서버에 Certbot(Let's Encrypt) 설치 및 인증서 발급
- Nginx 설정 수정:
  - 80 포트 접속 시 443(HTTPS)으로 리다이렉트
  - Certbot Webroot 인증 방식 연동 (/.well-known/acme-challenge/)
  - SSL 인증서 경로 설정
- Docker Compose 수정: Host의 인증서 파일 및 갱신 폴더를 컨테이너와 공유하기 위한 Volume 마운트 추가

### 인스턴스 내 작업 내역
1. Certbot 설치 및 인증 확인용 폴더 생성
```bash
sudo apt install certbot -y
sudo mkdir -p /var/www/certbot
```

2. 초기 인증서 발급(standalone 방식)
```bash
sudo certbot certonly --standalone -d teamconfig.work --email <email> --agree-tos --no-eff-email
```

3. 인증서 자동 갱신 스크립트 등록
> 매월 1일 인증서 갱신을 시도하고, 성공 시 Nginx 컨테이너 설정을 리로드하도록 스케줄링
```bash
sudo crontab -e 0 3 1 * * certbot renew --webroot -w /var/www/certbot --post-hook "docker exec web15-ipconfig-frontend nginx -s reload" >> /var/log/certbot-renew.log 2>&1
```

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
### 기존 ping 명령어를 통한 지연시간
```bash
--- teamconfig.work ping statistics ---
10 packets transmitted, 10 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 134.938/144.141/178.079/13.753 ms
```
### 기존 traceroute를 통한 경로 분석 결과
```bash
traceroute to teamconfig.work, 64 hops max, 40 byte packets
 1  my ip  4.453 ms  2.116 ms  2.145 ms
 2  121.130.119.254 (121.130.119.254)  5.022 ms  6.433 ms *
 ...
 6  112.174.86.178 (112.174.86.178)  9.429 ms
 7  112.174.87.130 (112.174.87.130)  139.488 ms  <-- Latency 급증 구간
 8  121.189.3.14 (121.189.3.14)  136.887 ms
 9  141.101.72.19 (141.101.72.19)  137.156 ms
10  172.67.130.24 (172.67.130.24)  132.478 ms  <-- Cloudflare Server 도달
```

132ms는 Cloudflare Edge 서버까지의 도달 시간이며, 이후 실제 Origin 서버(NCP)로의 프록시 과정까지 포함하면 실제 체감 지연 시간은 이보다 더 길 것으로 추정됩니다.

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. 해당 pr 병합 이후 ping 명령어를 통해 latency를 확인합니다.

## 💬 참고 사항

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
