### PR TITLE
feat: 기술 스택 위젯 별 요소 분리 및 주제 헤더 추가

### DIFF
--- a/backend/src/markdown/__test__/markdown.service.spec.ts
+++ b/backend/src/markdown/__test__/markdown.service.spec.ts
@@ -182,11 +182,10 @@ describe('MarkdownService', () => {
 
     const markdown = service.generateMarkdown(workspaceId);
 
-    expect(markdown).toContain('## 🛠 기술 스택 선택');
+    expect(markdown).toContain('## 🛠 기술 스택');
     expect(markdown).toContain('### Frontend');
     expect(markdown).toContain('React');
     expect(markdown).toContain('TypeScript');
-    expect(markdown).toContain('최신 버전');
   });
 
   it('GIT_CONVENTION 위젯이 있으면 그라운드 룰 마크다운을 생성한다.', () => {

--- a/backend/src/markdown/markdown.service.ts
+++ b/backend/src/markdown/markdown.service.ts
@@ -127,8 +127,6 @@ export class MarkdownService {
 
       if (content.techItems && content.techItems.length > 0) {
         lines.push(`### ${subject}`);
-        lines.push('| 기술 스택 이름 | 버전 |');
-        lines.push('| :--- | :--- |');
         content.techItems.forEach((item) => {
           lines.push(`- **${item.name}**`);
         });


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- PR 관련 라벨을 붙여주세요! -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- #271 

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- 기술 스택 위젯별로 분리해서 마크다운 생성하도록 수정
- 기술 스택 위젯의 주제 포함하여 마크다운 생성하도록 수정
- 기술 스택 위젯 마크다운 생성 로직 유닛 테스트 수정

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="1470" height="813" alt="image" src="https://github.com/user-attachments/assets/f670689a-6b53-4af3-adfa-37e41e9bc5ad" />

