### PR TITLE
chore: Docker Compose 인스턴스별 파일 분리

### DIFF
--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,13 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: web15-ipconfig-redis
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes --bind 0.0.0.0 --protected-mode no
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/docker-compose.was.yml
+++ b/docker-compose.was.yml
@@ -1,0 +1,11 @@
+services:
+  backend:
+    image: ${BACKEND_IMAGE:-ghcr.io/boostcampwm2025/web15-ipconfig/backend:latest}
+    container_name: web15-ipconfig-backend
+    ports:
+      - '3000:3000'
+    env_file:
+      - .env
+    volumes:
+      - /var/log/web15-ipconfig:/app/logs
+    restart: unless-stopped

--- a/docker-compose.webserver.yml
+++ b/docker-compose.webserver.yml
@@ -1,0 +1,11 @@
+services:
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/boostcampwm2025/web15-ipconfig/frontend:latest}
+    container_name: web15-ipconfig-frontend
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot
+    restart: unless-stopped


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- PR 관련 라벨을 붙여주세요! -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #389 

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- AWS 3-Instance 분리 구조에 맞춰 Docker Compose 파일을 인스턴스별로 분리
- NCP Container Registry 의존성 제거, GHCR 이미지 경로 사용
- 이미지 경로를 환경변수(`FRONTEND_IMAGE`, `BACKEND_IMAGE`)로 분리하여 유연성 확보

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. 각 compose 파일의 YAML 문법 확인: `docker compose -f docker-compose.webserver.yml config

## 💬 참고 사항

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
- 인스턴스별 컨테이너가 1개씩이므로 Docker `networks` 설정은 제거했습니다
- Redis는 CI/CD 배포에서 제외하여 배포 시 데이터가 유실되지 않도록 했습니다
- `nginx.conf`의 `proxy_pass` 변경은 #390 에서 별도 처리합니다