### PR TITLE
chore: CI/CD 파이프라인 NCP에서 AWS + GHCR로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
             echo "Waiting for WAS..."
             sleep 10
             for i in {1..10}; do
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/api/health || true)
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:${{ secrets.BACKEND_PORT }}/api/health || true)
               if [ "$HTTP_CODE" -eq 200 ]; then
                 echo "WAS Health Check Passed! (HTTP $HTTP_CODE)"
                 exit 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,7 +138,7 @@ jobs:
             # .env 파일 생성 (NestJS 환경변수 + Redis 접속 정보)
             cat <<EOF > .env
             NODE_ENV=production
-            PORT=3000
+            PORT=${{ secrets.BACKEND_PORT }}
             HOST_URL=${{ secrets.HOST_URL }}
             BACKEND_IMAGE=${{ env.IMAGE_PREFIX }}/backend:latest
             REDIS_HOST=${{ secrets.AWS_DB_PRIVATE_IP }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Copy compose file to WebServer
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.AWS_WEBSERVER_HOST }}
+          host: ${{ secrets.AWS_WEBSERVER_PUBLIC_IP }}
           username: ${{ secrets.AWS_SSH_USER }}
           key: ${{ secrets.AWS_SSH_KEY }}
           source: 'docker-compose.webserver.yml'
@@ -67,7 +67,7 @@ jobs:
       - name: Deploy Frontend to WebServer
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.AWS_WEBSERVER_HOST }}
+          host: ${{ secrets.AWS_WEBSERVER_PUBLIC_IP }}
           username: ${{ secrets.AWS_SSH_USER }}
           key: ${{ secrets.AWS_SSH_KEY }}
           script: |
@@ -118,18 +118,24 @@ jobs:
       - name: Copy compose file to WAS
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.AWS_WAS_HOST }}
+          host: ${{ secrets.AWS_WAS_PRIVATE_IP }}
           username: ${{ secrets.AWS_SSH_USER }}
           key: ${{ secrets.AWS_SSH_KEY }}
+          proxy_host: ${{ secrets.AWS_WEBSERVER_PUBLIC_IP }}
+          proxy_username: ${{ secrets.AWS_SSH_USER }}
+          proxy_key: ${{ secrets.AWS_SSH_KEY }}
           source: 'docker-compose.was.yml'
           target: '~/app/'
 
       - name: Deploy Backend to WAS
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.AWS_WAS_HOST }}
+          host: ${{ secrets.AWS_WAS_PRIVATE_IP }}
           username: ${{ secrets.AWS_SSH_USER }}
           key: ${{ secrets.AWS_SSH_KEY }}
+          proxy_host: ${{ secrets.AWS_WEBSERVER_PUBLIC_IP }}
+          proxy_username: ${{ secrets.AWS_SSH_USER }}
+          proxy_key: ${{ secrets.AWS_SSH_KEY }}
           script: |
             set -e
             mkdir -p ~/app
@@ -141,7 +147,7 @@ jobs:
             PORT=${{ secrets.BACKEND_PORT }}
             HOST_URL=${{ secrets.HOST_URL }}
             BACKEND_IMAGE=${{ env.IMAGE_PREFIX }}/backend:latest
-            REDIS_HOST=${{ secrets.AWS_DB_PRIVATE_IP }}
+            REDIS_HOST=${{ secrets.AWS_REDIS_PRIVATE_IP }}
             REDIS_PORT=${{ secrets.PROD_REDIS_PORT }}
             REDIS_PASSWORD=${{ secrets.PROD_REDIS_PASSWORD }}
             USE_REDIS_EXTENSION=${{ secrets.USE_REDIS_EXTENSION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,87 +48,129 @@ jobs:
             -f dockerfile.prod \
             --push .
 
-  deploy_to_server:
+  deploy_frontend:
     needs: build_and_push
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Copy docker-compose.prod.yml to server
+      - name: Copy compose file to WebServer
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.NCLOUD_HOST }}
-          username: ${{ secrets.NCLOUD_USER }}
-          key: ${{ secrets.NCLOUD_SSH_KEY }}
-          source: 'docker-compose.prod.yml'
+          host: ${{ secrets.AWS_WEBSERVER_HOST }}
+          username: ${{ secrets.AWS_SSH_USER }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          source: 'docker-compose.webserver.yml'
           target: '~/app/'
 
-      - name: SSH & Deploy
+      - name: Deploy Frontend to WebServer
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.NCLOUD_HOST }}
-          username: ${{ secrets.NCLOUD_USER }}
-          key: ${{ secrets.NCLOUD_SSH_KEY }}
+          host: ${{ secrets.AWS_WEBSERVER_HOST }}
+          username: ${{ secrets.AWS_SSH_USER }}
+          key: ${{ secrets.AWS_SSH_KEY }}
           script: |
             set -e
             mkdir -p ~/app
             cd ~/app
 
-            # .env 파일 생성 (Secrets 조합)
-            # Redis 및 기타 환경변수를 포함하여 .env 파일을 새로 작성합니다.
+            # .env 파일 생성 (docker-compose 변수 치환용)
             cat <<EOF > .env
-            NODE_ENV=production
-            PORT=${{ secrets.BACKEND_PORT }}
-            HOST_URL=${{ secrets.HOST_URL }}
-
-            # Docker 이미지 정보 (docker-compose 변수 치환용)
-            NCP_REGISTRY_ENDPOINT=${{ secrets.NCP_REGISTRY_ENDPOINT }}
-            BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}
-            FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}
-
-            # Redis 접속 정보 (NCP Cloud DB for Redis)
-            REDIS_HOST=${{ secrets.PROD_REDIS_HOST }}
-            REDIS_PORT=${{ secrets.PROD_REDIS_PORT }}
-            REDIS_PASSWORD=${{ secrets.PROD_REDIS_PASSWORD }}
-            USE_REDIS_EXTENSION=${{ secrets.USE_REDIS_EXTENSION }}
-            REDIS_TLS=false
-            LOG_DIR=${{ secrets.LOG_DIR }}
+            FRONTEND_IMAGE=${{ env.IMAGE_PREFIX }}/frontend:latest
+            WAS_HOST=${{ secrets.AWS_WAS_PRIVATE_IP }}
             EOF
 
-            # NCP Container Registry 로그인
-            echo "${{ secrets.NCP_SECRET_KEY }}" | docker login \
-              -u "${{ secrets.NCP_ACCESS_KEY }}" \
-              --password-stdin ${{ secrets.NCP_REGISTRY_ENDPOINT }}
+            # GHCR 로그인
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io \
+              -u ${{ github.actor }} --password-stdin
 
-            # 이미지 pull
-            docker pull ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.BACKEND_IMAGE }}
-            docker pull ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.FRONTEND_IMAGE }}
+            # 이미지 pull & 배포
+            docker compose -f docker-compose.webserver.yml pull
+            docker compose -f docker-compose.webserver.yml up -d
 
-            # 새 컨테이너 시작 (변경된 이미지만 교체, 다운타임 최소화)
-            # -d: 백그라운드 실행
-            docker compose -f docker-compose.prod.yml up -d
-
-            # 컨테이너 상태 확인
-            docker compose -f docker-compose.prod.yml ps
-
-            # 사용하지 않는 예전 이미지 삭제 (Dangling 이미지)
+            # 사용하지 않는 이미지 삭제
             docker image prune -f
 
             # Health Check
-            echo "Waiting for service to be ready..."
-            sleep 10
+            echo "Waiting for WebServer..."
+            sleep 5
             for i in {1..10}; do
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1/api/health || true)
-              if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 301 ] || [ "$HTTP_CODE" -eq 302 ]; then
-                echo "Health Check Passed! (HTTP $HTTP_CODE)"
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1 || true)
+              if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 301 ]; then
+                echo "WebServer Health Check Passed! (HTTP $HTTP_CODE)"
                 exit 0
               fi
-              echo "Waiting for service... ($i/10)"
+              echo "Waiting... ($i/10)"
               sleep 3
             done
-            echo "Health Check Failed!"
-            echo "Last HTTP Code: $HTTP_CODE"
-            # 실패 시 로그 출력
-            docker compose -f docker-compose.prod.yml logs --tail=50 backend
+            echo "WebServer Health Check Failed!"
+            docker compose -f docker-compose.webserver.yml logs --tail=30
+            exit 1
+
+  deploy_backend:
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy compose file to WAS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.AWS_WAS_HOST }}
+          username: ${{ secrets.AWS_SSH_USER }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          source: 'docker-compose.was.yml'
+          target: '~/app/'
+
+      - name: Deploy Backend to WAS
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.AWS_WAS_HOST }}
+          username: ${{ secrets.AWS_SSH_USER }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          script: |
+            set -e
+            mkdir -p ~/app
+            cd ~/app
+
+            # .env 파일 생성 (NestJS 환경변수 + Redis 접속 정보)
+            cat <<EOF > .env
+            NODE_ENV=production
+            PORT=3000
+            HOST_URL=${{ secrets.HOST_URL }}
+            BACKEND_IMAGE=${{ env.IMAGE_PREFIX }}/backend:latest
+            REDIS_HOST=${{ secrets.AWS_DB_PRIVATE_IP }}
+            REDIS_PORT=${{ secrets.PROD_REDIS_PORT }}
+            REDIS_PASSWORD=${{ secrets.PROD_REDIS_PASSWORD }}
+            USE_REDIS_EXTENSION=${{ secrets.USE_REDIS_EXTENSION }}
+            LOG_DIR=/app/logs
+            EOF
+
+            # GHCR 로그인
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io \
+              -u ${{ github.actor }} --password-stdin
+
+            # 이미지 pull & 배포
+            docker compose -f docker-compose.was.yml pull
+            docker compose -f docker-compose.was.yml up -d
+
+            # 사용하지 않는 이미지 삭제
+            docker image prune -f
+
+            # Health Check
+            echo "Waiting for WAS..."
+            sleep 10
+            for i in {1..10}; do
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/api/health || true)
+              if [ "$HTTP_CODE" -eq 200 ]; then
+                echo "WAS Health Check Passed! (HTTP $HTTP_CODE)"
+                exit 0
+              fi
+              echo "Waiting... ($i/10)"
+              sleep 3
+            done
+            echo "WAS Health Check Failed!"
+            docker compose -f docker-compose.was.yml logs --tail=50
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy with Docker Compose
+name: Deploy to AWS
 
 on:
   push:
@@ -6,13 +6,14 @@ on:
       - main
 
 env:
-  NODE_VERSION: '24.12.0'
-  FRONTEND_IMAGE: web15-ipconfig-frontend:latest
-  BACKEND_IMAGE: web15-ipconfig-backend:latest
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/web15-ipconfig
 
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,47 +25,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Backend Image
+      - name: Log in to GHCR
         run: |
-          docker build -t ${{ env.BACKEND_IMAGE }} \
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+
+      - name: Build & Push Backend Image
+        run: |
+          docker buildx build \
+            -t ${{ env.IMAGE_PREFIX }}/backend:latest \
+            -t ${{ env.IMAGE_PREFIX }}/backend:${{ steps.sha.outputs.SHORT_SHA }} \
             --target backend-prod \
-            -f dockerfile.prod .
+            -f dockerfile.prod \
+            --push .
 
-      - name: Build Frontend Image
+      - name: Build & Push Frontend Image
         run: |
-          docker build -t ${{ env.FRONTEND_IMAGE }} \
+          docker buildx build \
+            -t ${{ env.IMAGE_PREFIX }}/frontend:latest \
+            -t ${{ env.IMAGE_PREFIX }}/frontend:${{ steps.sha.outputs.SHORT_SHA }} \
             --target frontend-prod \
-            -f dockerfile.prod .
-
-      - name: Log in to NCP Container Registry
-        run: |
-          echo "${{ secrets.NCP_SECRET_KEY }}" | docker login \
-            -u "${{ secrets.NCP_ACCESS_KEY }}" \
-            --password-stdin ${{ secrets.NCP_REGISTRY_ENDPOINT }}
-
-      - name: Tag Backend Image
-        run: |
-          docker tag ${{ env.BACKEND_IMAGE }} \
-            ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.BACKEND_IMAGE }}
-          docker tag ${{ env.BACKEND_IMAGE }} \
-            ${{ secrets.NCP_REGISTRY_ENDPOINT }}/web15-ipconfig-backend:${{ steps.sha.outputs.SHORT_SHA }}
-
-      - name: Tag Frontend Image
-        run: |
-          docker tag ${{ env.FRONTEND_IMAGE }} \
-            ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.FRONTEND_IMAGE }}
-          docker tag ${{ env.FRONTEND_IMAGE }} \
-            ${{ secrets.NCP_REGISTRY_ENDPOINT }}/web15-ipconfig-frontend:${{ steps.sha.outputs.SHORT_SHA }}
-
-      - name: Push Backend Image
-        run: |
-          docker push ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.BACKEND_IMAGE }}
-          docker push ${{ secrets.NCP_REGISTRY_ENDPOINT }}/web15-ipconfig-backend:${{ steps.sha.outputs.SHORT_SHA }}
-
-      - name: Push Frontend Image
-        run: |
-          docker push ${{ secrets.NCP_REGISTRY_ENDPOINT }}/${{ env.FRONTEND_IMAGE }}
-          docker push ${{ secrets.NCP_REGISTRY_ENDPOINT }}/web15-ipconfig-frontend:${{ steps.sha.outputs.SHORT_SHA }}
+            -f dockerfile.prod \
+            --push .
 
   deploy_to_server:
     needs: build_and_push


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- PR 관련 라벨을 붙여주세요! -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #388

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- 이미지 레지스트리 전환 (NCP → GHCR)
  - NCP Container Registry 로그인/태그/푸시 → GHCR 로그인 + `docker buildx build --push` 통합
  - `GITHUB_TOKEN` 기반 인증으로 별도 Secret 불필요
  - `IMAGE_PREFIX` 환경변수로 이미지 경로 통합 관리
  - `packages: write` 권한 추가

- 배포 Job 인스턴스별 분리
  - 기존 `deploy_to_server` (NCP 단일 서버) → `deploy_frontend` + `deploy_backend` 병렬 실행
  - WebServer: `docker-compose.webserver.yml` 기반 Nginx + 프론트엔드 배포
  - WAS: `docker-compose.was.yml `기반 NestJS 백엔드 배포
  - 인스턴스별 독립 Health Check

## 💬 참고 사항

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
- GHCR_PAT(pat classic, `read: package`) 시크릿의 경우 90일의 만료 기한으로 설정했습니다.  90일 간격으로 업데이트가 필요합니다.